### PR TITLE
Fix main property in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "iso-4217-currency-codes-angular",
   "version": "1.0.1",
-  "main": "dist/iso-4217-currency-codes-angular.js",
+  "main": "dist/iso-4217-currency-codes-angular.min.js",
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
Pointing to non-existent file causes file to not be included `main-bower-files` and similar automation.